### PR TITLE
fix: include typing directory when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "/android",
     "!/android/build",
     "/ios",
-    "/*.podspec"
+    "/*.podspec",
+    "/typings"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Typing is missing when publishing to npm