### PR TITLE
feat: Add more code types to decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ payload
 |    Property    | Type     | Description  |
 | :------------- | :------: | :----------- |
 | values         | string[]   | Array of detected QR code values. Empty if nothing found.
+| type           | string     | Type of detected code.
+
+The following barcode types are currently supported for decoding:
+
+* UPC-A and UPC-E
+* EAN-8 and EAN-13
+* Code 39
+* Code 93
+* Code 128
+* ITF
+* Codabar
+* RSS-14 (all variants)
+* QR Code
+* Data Matrix
+* Maxicode
+* Aztec ('beta' quality)
+* PDF 417 ('beta' quality)
+
 
 
 ![example](https://user-images.githubusercontent.com/13519034/104821872-50268480-5858-11eb-9e5b-77190f9da71d.gif)
@@ -132,5 +150,7 @@ RNQRGenerator.generate({
 
 More information about totp can be found [here](https://github.com/google/google-authenticator/wiki/Key-Uri-Format).
 
+
+This module uses `Zxing` library for encoding and decoding codes ( [ios](https://github.com/zxingify/zxingify-objc), [Android](https://github.com/journeyapps/zxing-android-embedded)).
 # Note
 Some simulators may not generate qr code properly. Use real device if you get an error.

--- a/RNQrGenerator.podspec
+++ b/RNQrGenerator.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
+  s.dependency "ZXingObjC"
 end
 
   

--- a/example/QRGeneratorExample/App.js
+++ b/example/QRGeneratorExample/App.js
@@ -71,8 +71,9 @@ const App: () => React$Node = () => {
       setDetectImageUri({uri: response.uri});
       RNQRGenerator.detect({uri: response.uri})
         .then((res) => {
+          console.log('Detected', res);
           if (res.values.length === 0) {
-            setDetectedValues(['QR code not found']);
+            setDetectedValues(['Code not found']);
           } else {
             setDetectedValues(res.values);
           }

--- a/example/QRGeneratorExample/package.json
+++ b/example/QRGeneratorExample/package.json
@@ -13,7 +13,7 @@
     "react": "16.13.1",
     "react-native": "0.63.4",
     "react-native-image-picker": "^3.1.3",
-    "rn-qr-generator": "^1.1.4"
+    "rn-qr-generator": "^1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/index.js
+++ b/index.js
@@ -41,8 +41,13 @@ export type QRCodeDetectOptions = {
   base64?: string,
 };
 
+export type CodeType = 'Aztec' | 'Codabar' | 'Code39' | 'Code93' | 'Code128' |
+  'DataMatrix' | 'Ean8' | 'Ean13' | 'ITF' | 'MaxiCode' | 'PDF417' | 'QRCode' |
+  'RSS14' | 'RSSExpanded' | 'UPCA' | 'UPCE' | 'UPCEANExtension';
+
 export type QRCodeScanResult = {
   values: string[],
+  type: CodeType
 };
 
 export default {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rn-qr-generator",
-  "version": "1.1.7",
-  "description": "React native QR Code generator",
+  "version": "1.2.0",
+  "description": "React native QR Code generator / reader",
   "main": "index.js",
   "types": "typings/index.d.ts",
   "files": [
@@ -18,6 +18,8 @@
     "react-native",
     "qr",
     "qrcode",
+    "Data Matrix",
+    "DataMatrix",
     "qr generator",
     "qrcode image",
     "qr decode",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -34,8 +34,13 @@ export interface QRCodeDetectOptions {
   base64?: string;
 };
 
+export type CodeType = 'Aztec' | 'Codabar' | 'Code39' | 'Code93' | 'Code128' |
+  'DataMatrix' | 'Ean8' | 'Ean13' | 'ITF' | 'MaxiCode' | 'PDF417' | 'QRCode' |
+  'RSS14' | 'RSSExpanded' | 'UPCA' | 'UPCE' | 'UPCEANExtension';
+
 export interface QRCodeScanResult {
   values: Array<string>;
+  type: CodeType;
 };
 
 declare namespace RNQRGenerator {


### PR DESCRIPTION
Supported types are `Aztec`, `Codabar`, `Code39`, `Code93`, `Code128`, `DataMatrix`, `Ean8`, `Ean13`, `ITF`, `MaxiCode`, `PDF417`, `QRCode`, `RSS14`, `RSSExpanded`, `UPCA`, `UPCE`, `UPCEANExtension`