### PR TITLE
Fix Android Gradle Plugin error >= 8.x.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,10 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace = "com.gevorg.reactlibrary"
+    }
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)


### PR DESCRIPTION
follow https://stackoverflow.com/questions/76108428/how-do-i-fix-namespace-not-specified-error-in-android-studio

and https://github.com/getsentry/sentry-react-native/blob/main/android/build.gradle#L17C5-L20C6

which fixed Android Gradle Plugin error >= 8.x.x