### PR TITLE
fix: Ensure detect function works for all supported barcode formats

### DIFF
--- a/android/src/main/java/com/gevorg/reactlibrary/RNQrGeneratorModule.java
+++ b/android/src/main/java/com/gevorg/reactlibrary/RNQrGeneratorModule.java
@@ -324,11 +324,13 @@ public class RNQrGeneratorModule extends ReactContextBaseJavaModule {
 
     try {
       Result result = reader.decode(bitmap, hints);
+      Result[] results;
       if (result.getText() != "") {
-        Result [] results = new Result[1];
+        results = new Result[1];
         results[0] = result;
+      } else {
+        results = readerMulti.decodeMultiple(bitmap, hints);
       }
-      Result[] results = readerMulti.decodeMultiple(bitmap, hints);
       return results;
     } catch (Exception e) {
       Log.e("RNQRGenerator", "Decode Failed:", e);

--- a/ios/RNQrGenerator.m
+++ b/ios/RNQrGenerator.m
@@ -135,11 +135,9 @@ RCT_EXPORT_METHOD(detect:(NSDictionary *)options
 
     // There are a number of hints we can give to the reader, including
     // possible formats, allowed lengths, and the string encoding.
-    ZXDecodeHints *hints = [ZXDecodeHints hints];
-    [hints setTryHarder:TRUE];
-    [hints addPossibleFormat:kBarcodeFormatQRCode];
 
     ZXMultiFormatReader *reader = [ZXMultiFormatReader reader];
+    ZXDecodeHints *hints = [self createDecodeHints];
     ZXResult *result = [reader decode:bitmap
                                 hints:hints
                                 error:&error];
@@ -187,6 +185,31 @@ RCT_EXPORT_METHOD(detect:(NSDictionary *)options
           RCTLogWarn(@"Required iOS 8 or later");
       }
     }
+}
+
+- (ZXDecodeHints *)createDecodeHints {
+    ZXDecodeHints *hints = [ZXDecodeHints hints];
+    [hints setTryHarder:TRUE];
+
+    [hints addPossibleFormat:kBarcodeFormatAztec];
+    [hints addPossibleFormat:kBarcodeFormatCodabar];
+    [hints addPossibleFormat:kBarcodeFormatCode39];
+    [hints addPossibleFormat:kBarcodeFormatCode93];
+    [hints addPossibleFormat:kBarcodeFormatCode128];
+    [hints addPossibleFormat:kBarcodeFormatDataMatrix];
+    [hints addPossibleFormat:kBarcodeFormatEan8];
+    [hints addPossibleFormat:kBarcodeFormatEan13];
+    [hints addPossibleFormat:kBarcodeFormatITF];
+    [hints addPossibleFormat:kBarcodeFormatMaxiCode];
+    [hints addPossibleFormat:kBarcodeFormatPDF417];
+    [hints addPossibleFormat:kBarcodeFormatQRCode];
+    [hints addPossibleFormat:kBarcodeFormatRSS14];
+    [hints addPossibleFormat:kBarcodeFormatRSSExpanded];
+    [hints addPossibleFormat:kBarcodeFormatUPCA];
+    [hints addPossibleFormat:kBarcodeFormatUPCE];
+    [hints addPossibleFormat:kBarcodeFormatUPCEANExtension];
+
+    return hints;
 }
 
 - (NSString *)generatePathInDirectory:(NSString *)directory fileName:(NSString *)name withExtension:(NSString *)extension


### PR DESCRIPTION
✅ **iOS:**
Supported barcode formats have been extended by using the createDecodeHints method during decoding.
Now supports formats like QRCode, Code128, EAN13, Aztec, PDF417, and more.

✅ **Android:** 
QR code reading logic in RNQrGeneratorModule.java has been updated.
If MultiFormatReader.decode successfully detects a single barcode, the result is assigned to a Result[1] array.
If it fails, QRCodeMultiReader.decodeMultiple is used to search for multiple QR codes.
This ensures that if the barcode is not a QR code or cannot be decoded by MultiFormatReader, the fallback to QRCodeMultiReader enables detection of QR codes and enhances support for multiple formats.